### PR TITLE
Fix #3 Remove PID File if it exists on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ RUN apk --no-cache add minidlna
 # Add config file
 ADD minidlna.conf /etc/minidlna.conf
 
+# Copy entrypoint
+COPY entrypoint.sh /usr/bin/
+
 EXPOSE 1900/udp
 EXPOSE 8200
 
-ENTRYPOINT [ "/usr/sbin/minidlnad", "-S" ]
+ENTRYPOINT [ "entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ -e /run/minidlna/minidlna.pid ]; then
+    rm /run/minidlna/minidlna.pid
+fi
+
+exec /usr/sbin/minidlnad -S


### PR DESCRIPTION
Fix #3 

### To Reproduce

```
$ docker run -d --name testcontainer geekduck/minidlna
$ docker kill --signal=SIGKILL testcontainer
$ docker start testcontainer
testcontainer
$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
$ docker logs testcontainer
minidlna.c:961: error: MiniDLNA is already running. EXITING.
```

### Fixed Result

```
$ docker run -d --name testcontainer geekduck/minidlna
$ docker kill --signal=SIGKILL testcontainer
$ docker start testcontainer
$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                NAMES
56a97fde0506        geekduck/minidlna   "entrypoint.sh"     21 seconds ago      Up 1 second         1900/udp, 8200/tcp   testcontainer
```
